### PR TITLE
this would have never happened in elm

### DIFF
--- a/src/store/configureStore.prod.js
+++ b/src/store/configureStore.prod.js
@@ -1,6 +1,10 @@
-import {createStore} from 'redux';
+import { createStore, compose, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
 import rootReducer from '../reducers';
 
 export default function configureStore(initialState) {
-  return createStore(rootReducer, initialState);
+  return createStore(rootReducer, initialState, compose(
+    applyMiddleware(thunk)
+  )
+  );
 }


### PR DESCRIPTION
To reproduce, run:

 ```sh
npm run build
```

previously, page would have died on the following JS error:

> Actions must be plain objects. Use custom middleware for async actions.

Now, page renders correctly. 